### PR TITLE
fix base url from zadarma to novofone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "jlorente/zadarma-php-sdk",
+    "name": "mnovik/zadarma-php-sdk",
     "description": "A PHP package to access the Zadarma API by a comprehensive way.",
     "keywords": [
         "php",
-        "jlorente",
+        "mnovik",
         "zadarma"
     ],
     "license": "BSD-3-Clause",
     "authors": [
         {
-            "name": "José Lorente",
-            "email": "jose.lorente.martin@gmail.com"
+            "name": "Matt Novik after José Lorente",
+            "email": "matvej.novik@gmail.com"
         }
     ],
     "require": {

--- a/src/Core/Api.php
+++ b/src/Core/Api.php
@@ -56,7 +56,7 @@ abstract class Api implements ApiInterface
      */
     public function baseUrl()
     {
-        return 'https://api.zadarma.com';
+        return 'https://api.novofone.com';
     }
 
     /**


### PR DESCRIPTION
Hi, after new update from zadarma/novofone, they have changed their api url
From 'https://api.zadarma.com/' to 'https://api.novofone.com/'

And now - we have error when try to make calls